### PR TITLE
resolves #24

### DIFF
--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -6,16 +6,9 @@ import Definition from './../Definition'
 class FileLoader {
   /**
    * @param {ContainerBuilder} container
-   * @param {string|null} filePath
    */
-  constructor (container, filePath = null) {
+  constructor (container) {
     this._container = container
-    if (filePath) {
-      this._container.logger.warn('DEPRECATED',
-        'The second argument in the FileLoader is deprecated. Please send the file path in the load method instead.'
-      )
-      this._filePath = filePath
-    }
   }
 
   /**
@@ -23,14 +16,7 @@ class FileLoader {
    * @protected
    */
   _checkFile (file) {
-    if (!file) {
-      this._container.logger.warn('DEPRECATED',
-        'The null argument in the load method is deprecated. ' +
-        'Please send the file path in this method instead of in the file load constructor'
-      )
-    } else {
-      this.filePath = file
-    }
+    this.filePath = file
   }
 
   /**

--- a/test/node-dependency-injection/lib/Loader/JsFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/JsFileLoader.spec.js
@@ -114,25 +114,4 @@ describe('JsFileLoader', () => {
       return assert.instanceOf(baz, FooBar)
     })
   })
-
-  describe('old way of loading js config file', () => {
-    beforeEach(() => {
-      container = new ContainerBuilder()
-      container.logger = logger
-      loader = new JsFileLoader(container,
-        path.join(__dirname, '/../../../Resources/config/fake-services.js'))
-    })
-
-    it('should load multiple service files', () => {
-      // Arrange.
-      let serviceName = 'foo'
-
-      // Act.
-      loader.load()
-      let service = container.get(serviceName)
-
-      // Assert.
-      return assert.instanceOf(service, Foo)
-    })
-  })
 })

--- a/test/node-dependency-injection/lib/Loader/JsonFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/JsonFileLoader.spec.js
@@ -117,25 +117,4 @@ describe('JsonFileLoader', () => {
       return assert.instanceOf(baz, FooBar)
     })
   })
-
-  describe('old way of loading json config file', () => {
-    beforeEach(() => {
-      container = new ContainerBuilder()
-      container.logger = logger
-      loader = new JsonFileLoader(container,
-        path.join(__dirname, '/../../../Resources/config/fake-services.json'))
-    })
-
-    it('should load multiple service files', () => {
-      // Arrange.
-      let serviceName = 'foo'
-
-      // Act.
-      loader.load()
-      let service = container.get(serviceName)
-
-      // Assert.
-      return assert.instanceOf(service, Foo)
-    })
-  })
 })

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -228,25 +228,4 @@ describe('YamlFileLoader', () => {
       return assert.instanceOf(baz, FooBar)
     })
   })
-
-  describe('old way of loading yaml config file', () => {
-    beforeEach(() => {
-      container = new ContainerBuilder()
-      container.logger = logger
-      loader = new YamlFileLoader(container,
-        path.join(__dirname, '/../../../Resources/config/fake-services.yml'))
-    })
-
-    it('should load multiple service files', () => {
-      // Arrange.
-      let serviceName = 'foo'
-
-      // Act.
-      loader.load()
-      let service = container.get(serviceName)
-
-      // Assert.
-      return assert.instanceOf(service, Foo)
-    })
-  })
 })


### PR DESCRIPTION
* Remove deprecations and disable the second argument in the FileLoader constructor
* Remove deprecations and make it mandatory the argument in the load method of each FileLoader interface