### PR TITLE
Support named exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ List of features
 - Synthetic Services
 - Non Shared Services
 - Parent and Abstract Services
+- Services from named and default exports
 - Custom Logger
 - Container as Service
 

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -7,7 +7,7 @@ class FileLoader {
   /**
    * @param {ContainerBuilder} container
    */
-  constructor (container) {
+  constructor(container) {
     this._container = container
   }
 
@@ -15,28 +15,28 @@ class FileLoader {
    * @param {string} file
    * @protected
    */
-  _checkFile (file) {
+  _checkFile(file) {
     this.filePath = file
   }
 
   /**
    * @returns {ContainerBuilder}
    */
-  get container () {
+  get container() {
     return this._container
   }
 
   /**
    * @returns {string}
    */
-  get filePath () {
+  get filePath() {
     return this._filePath
   }
 
   /**
    * @param {string} value
    */
-  set filePath (value) {
+  set filePath(value) {
     this._filePath = value
   }
 
@@ -45,7 +45,7 @@ class FileLoader {
    *
    * @protected
    */
-  _parseDefinitions (services = []) {
+  _parseDefinitions(services = []) {
     for (const id in services) {
       this._parseDefinition(services, id)
     }
@@ -56,7 +56,7 @@ class FileLoader {
    * @param {string} id
    * @private
    */
-  _parseDefinition (services, id) {
+  _parseDefinition(services, id) {
     const service = services[id]
 
     if (typeof service === 'string') {
@@ -73,7 +73,7 @@ class FileLoader {
    * @returns {Definition}
    * @private
    */
-  _getFactoryDefinition (service) {
+  _getFactoryDefinition(service) {
     let object = null
 
     if (service.factory.class.includes('@', 0)) {
@@ -95,11 +95,11 @@ class FileLoader {
    * @returns {Definition}
    * @private
    */
-  _getDefinition (service) {
+  _getDefinition(service) {
     let definition
 
     if (!service.synthetic) {
-      const object = this._requireClassNameFromPath(service.class, service.main)
+      const object = this._requireClassNameFromPath(service.class, service.main || 'default')
       definition = new Definition(object)
       definition.lazy = service.lazy || false
       definition.public = service.public !== false
@@ -127,7 +127,7 @@ class FileLoader {
    * @param {Array} calls
    * @private
    */
-  _parseCalls (definition, calls = []) {
+  _parseCalls(definition, calls = []) {
     calls.map((call) => {
       definition.addMethodCall(call.method,
         this._getParsedArguments(call.arguments))
@@ -139,7 +139,7 @@ class FileLoader {
    * @param {Array} tags
    * @private
    */
-  _parseTags (definition, tags = []) {
+  _parseTags(definition, tags = []) {
     tags.map((tag) => {
       definition.addTag(tag.name,
         FileLoader._parseTagAttributes(tag.attributes))
@@ -151,7 +151,7 @@ class FileLoader {
    * @returns {Array}
    * @private
    */
-  _getParsedArguments (args = []) {
+  _getParsedArguments(args = []) {
     const parsedArguments = []
     args.map((argument) => {
       parsedArguments.push(this._parseArgument(argument))
@@ -165,7 +165,7 @@ class FileLoader {
    * @returns Map
    * @private
    */
-  static _parseTagAttributes (attributes) {
+  static _parseTagAttributes(attributes) {
     const map = new Map()
 
     if (attributes) {
@@ -182,7 +182,7 @@ class FileLoader {
    * @param {Object} properties
    * @private
    */
-  _parseProperties (definition, properties = {}) {
+  _parseProperties(definition, properties = {}) {
     for (const propertyKey in properties) {
       definition.addProperty(propertyKey, this._parseArgument(properties[propertyKey]))
     }
@@ -193,7 +193,7 @@ class FileLoader {
    *
    * @protected
    */
-  _parseImports (imports = []) {
+  _parseImports(imports = []) {
     for (const file of imports) {
       const workingPath = this.filePath
       this.load(path.join(path.dirname(this.filePath), file.resource))
@@ -206,7 +206,7 @@ class FileLoader {
    *
    * @protected
    */
-  _parseParameters (parameters = {}) {
+  _parseParameters(parameters = {}) {
     for (const key in parameters) {
       this._container.setParameter(key, parameters[key])
     }
@@ -218,7 +218,7 @@ class FileLoader {
    *
    * @private
    */
-  _parseArguments (definition, args = []) {
+  _parseArguments(definition, args = []) {
     const argument = (definition.abstract) ? 'appendArgs' : 'args'
     definition[argument] = this._getParsedArguments(args)
   }
@@ -229,7 +229,7 @@ class FileLoader {
    *
    * @private
    */
-  _parseArgument (argument) {
+  _parseArgument(argument) {
     if (typeof argument === 'boolean') {
       return argument
     }
@@ -254,7 +254,7 @@ class FileLoader {
    *
    * @private
    */
-  _requireClassNameFromPath (classObject, main) {
+  _requireClassNameFromPath(classObject, main) {
     let fromDirectory = (!path.isAbsolute(classObject)) ? path.dirname(
       this.filePath) : '/'
     fromDirectory = this.container.defaultDir || fromDirectory

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -99,7 +99,7 @@ class FileLoader {
     let definition
 
     if (!service.synthetic) {
-      const object = this._requireClassNameFromPath(service.class)
+      const object = this._requireClassNameFromPath(service.class, service.main)
       definition = new Definition(object)
       definition.lazy = service.lazy || false
       definition.public = service.public !== false
@@ -249,15 +249,16 @@ class FileLoader {
 
   /**
    * @param {string} classObject
+   * @param {string} main
    * @returns {*}
    *
    * @private
    */
-  _requireClassNameFromPath (classObject) {
+  _requireClassNameFromPath (classObject, main) {
     let fromDirectory = (!path.isAbsolute(classObject)) ? path.dirname(
       this.filePath) : '/'
     fromDirectory = this.container.defaultDir || fromDirectory
-    return require(path.join(fromDirectory, classObject)).default
+    return require(path.join(fromDirectory, classObject))[main]
   }
 }
 

--- a/test/Resources/config/main.yml
+++ b/test/Resources/config/main.yml
@@ -1,0 +1,7 @@
+services:
+  one:
+    class: ./../multipleExports
+    main: ClassOne
+  two:
+    class: ./../multipleExports
+    main: ClassTwo

--- a/test/Resources/multipleExports.js
+++ b/test/Resources/multipleExports.js
@@ -1,0 +1,3 @@
+export class ClassOne {}
+
+export class ClassTwo {}

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -314,7 +314,7 @@ describe('YamlFileLoader', () => {
       container.compile()
     })
 
-    it.only('should load instance of service properly', () => {
+    it('should load instance of service properly', () => {
       // Arrange.
       const configPath = path.join(
         __dirname,

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -15,6 +15,7 @@ import Mailer from '../../../Resources/Mailer'
 import DecoratingMailerTwo from '../../../Resources/DecoratingMailerTwo'
 import ChildClass from '../../../Resources/abstract/ChildClass'
 import Service from '../../../Resources/abstract/Service'
+import { ClassOne, ClassTwo } from '../../../Resources/multipleExports'
 
 const assert = chai.assert
 
@@ -23,7 +24,7 @@ describe('YamlFileLoader', () => {
   let loaderSelfReference
   let container
   let containerSelfReference
-  const logger = { warn: () => {} }
+  const logger = { warn: () => { } }
 
   describe('load', () => {
     beforeEach(() => {
@@ -303,6 +304,31 @@ describe('YamlFileLoader', () => {
       assert.instanceOf(child, ChildClass)
       assert.instanceOf(service, Service)
       return assert.instanceOf(mailer, Mailer)
+    })
+  })
+
+  describe('load with main', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      loader = new YamlFileLoader(container)
+      container.compile()
+    })
+
+    it.only('should load instance of service properly', () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/main.yml'
+      )
+
+      // Act.
+      loader.load(configPath)
+      const one = container.get('one')
+      const two = container.get('two')
+
+      // Assert.
+      assert.instanceOf(one, ClassOne)
+      return assert.instanceOf(two, ClassTwo)
     })
   })
 })


### PR DESCRIPTION
This PR is related to the closed issue #128.

I added "main" option to file loader in order to allow users loading services from non-default exports (i.e. named exports).

Some alternatives to "main" name were taken into account, such as "require", "module, "entry-point", "import". Feel free to choose any other if you don't like "main".