### PR TITLE
Support named exports

### DIFF
--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -249,16 +249,18 @@ class FileLoader {
 
   /**
    * @param {string} classObject
-   * @param {string} main
+   * @param {string} mainClassName
    * @returns {*}
    *
    * @private
    */
-  _requireClassNameFromPath (classObject, main = 'default') {
+  _requireClassNameFromPath (classObject, mainClassName) {
     let fromDirectory = (!path.isAbsolute(classObject)) ? path.dirname(
       this.filePath) : '/'
     fromDirectory = this.container.defaultDir || fromDirectory
-    return require(path.join(fromDirectory, classObject))[main]
+    const className = mainClassName || path.basename(classObject)
+    const exportedModule = require(path.join(fromDirectory, classObject))
+    return exportedModule.default || exportedModule[className]
   }
 }
 

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -99,7 +99,7 @@ class FileLoader {
     let definition
 
     if (!service.synthetic) {
-      const object = this._requireClassNameFromPath(service.class)
+      const object = this._requireClassNameFromPath(service.class, service.main)
       definition = new Definition(object)
       definition.lazy = service.lazy || false
       definition.public = service.public !== false
@@ -249,15 +249,16 @@ class FileLoader {
 
   /**
    * @param {string} classObject
+   * @param {string} main
    * @returns {*}
    *
    * @private
    */
-  _requireClassNameFromPath (classObject) {
+  _requireClassNameFromPath (classObject, main = 'default') {
     let fromDirectory = (!path.isAbsolute(classObject)) ? path.dirname(
       this.filePath) : '/'
     fromDirectory = this.container.defaultDir || fromDirectory
-    return require(path.join(fromDirectory, classObject)).default
+    return require(path.join(fromDirectory, classObject))[main]
   }
 }
 

--- a/test/Resources/NamedService.js
+++ b/test/Resources/NamedService.js
@@ -1,0 +1,1 @@
+export class NamedService { }

--- a/test/Resources/config/main.yml
+++ b/test/Resources/config/main.yml
@@ -1,0 +1,7 @@
+services:
+  one:
+    class: ./../multipleExports
+    main: ClassOne
+  two:
+    class: ./../multipleExports
+    main: ClassTwo

--- a/test/Resources/config/named-service.yml
+++ b/test/Resources/config/named-service.yml
@@ -1,0 +1,3 @@
+services:
+  named:
+    class: ./../NamedService

--- a/test/Resources/multipleExports.js
+++ b/test/Resources/multipleExports.js
@@ -1,0 +1,3 @@
+export class ClassOne { }
+
+export class ClassTwo { }

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -16,6 +16,7 @@ import DecoratingMailerTwo from '../../../Resources/DecoratingMailerTwo'
 import ChildClass from '../../../Resources/abstract/ChildClass'
 import Service from '../../../Resources/abstract/Service'
 import { ClassOne, ClassTwo } from '../../../Resources/multipleExports'
+import { NamedService } from '../../../Resources/NamedService'
 
 const assert = chai.assert
 
@@ -228,6 +229,19 @@ describe('YamlFileLoader', () => {
 
       // Assert.
       return assert.instanceOf(syntheticService, SyntheticService)
+    })
+
+    it('should load properly service without default export', () => {
+      // Arrange.
+      const serviceName = 'named'
+
+      // Act.
+      loader.load(
+        path.join(__dirname, '/../../../Resources/config/named-service.yml'))
+      const service = container.get(serviceName)
+
+      // Assert.
+      return assert.instanceOf(service, NamedService)
     })
   })
 

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -15,6 +15,7 @@ import Mailer from '../../../Resources/Mailer'
 import DecoratingMailerTwo from '../../../Resources/DecoratingMailerTwo'
 import ChildClass from '../../../Resources/abstract/ChildClass'
 import Service from '../../../Resources/abstract/Service'
+import { ClassOne, ClassTwo } from '../../../Resources/multipleExports'
 
 const assert = chai.assert
 
@@ -23,7 +24,7 @@ describe('YamlFileLoader', () => {
   let loaderSelfReference
   let container
   let containerSelfReference
-  const logger = { warn: () => {} }
+  const logger = { warn: () => { } }
 
   describe('load', () => {
     beforeEach(() => {
@@ -303,6 +304,31 @@ describe('YamlFileLoader', () => {
       assert.instanceOf(child, ChildClass)
       assert.instanceOf(service, Service)
       return assert.instanceOf(mailer, Mailer)
+    })
+  })
+
+  describe('load with main', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      loader = new YamlFileLoader(container)
+      container.compile()
+    })
+
+    it('should load instance of service properly', () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/main.yml'
+      )
+
+      // Act.
+      loader.load(configPath)
+      const one = container.get('one')
+      const two = container.get('two')
+
+      // Assert.
+      assert.instanceOf(one, ClassOne)
+      return assert.instanceOf(two, ClassTwo)
     })
   })
 })


### PR DESCRIPTION
This PR is related to the closed issue #128.

I added "main" option to file loader in order to allow users loading services from non-default exports (i.e. named exports).

Some alternatives to "main" name were taken into account, such as "require", "module, "entry-point", "import". Feel free to choose any other if you don't like "main".

EDIT: Since it is very usual that the filename matches the exported class name, if the module has no default export and "main" is not defined, then the filename is used as class name