### PR TITLE
Add support for defining service's arguments using tags

### DIFF
--- a/lib/InstanceManager.js
+++ b/lib/InstanceManager.js
@@ -1,4 +1,5 @@
 import Reference from './Reference'
+import TagReference from './TagReference'
 import PackageReference from './PackageReference'
 import PrivateServiceException from './Exception/PrivateServiceException'
 import ServiceNotFoundException from './Exception/ServiceNotFoundException'
@@ -195,11 +196,25 @@ export default class InstanceManager {
       }
     } else if (value instanceof PackageReference) {
       return require(value.id)
+    } else if (value instanceof TagReference) {
+      return this._findTaggedServices(value.name)
     } else {
       return value
     }
 
     return null
+  }
+
+  _findTaggedServices (tagName) {
+    const taggedServices = []
+    for (const [id, definition] of this._definitions) {
+      if (definition.tags.some((tag) => { return tag.name === tagName })) {
+        const serviceInstance = this.getInstance(id)
+        taggedServices.push(serviceInstance)
+      }
+    }
+
+    return taggedServices
   }
 
   /**

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -1,6 +1,7 @@
 import path from 'path'
 import Reference from './../Reference'
 import PackageReference from './../PackageReference'
+import TagReference from './../TagReference'
 import Definition from './../Definition'
 
 class FileLoader {
@@ -242,6 +243,8 @@ class FileLoader {
       return this._container.getParameter(argument.slice(1, -1))
     } else if (argument.slice(0, 1) === '%') {
       return new PackageReference(argument.slice(1))
+    } else if (argument.slice(0, 7) === '!tagged') {
+      return new TagReference(argument.slice(8))
     }
 
     return argument

--- a/lib/TagReference.js
+++ b/lib/TagReference.js
@@ -1,0 +1,17 @@
+class TagReference {
+  /**
+   * @param {string} name
+   */
+  constructor (name) {
+    this._name = name
+  }
+
+  /**
+   * @returns {string}
+   */
+  get name () {
+    return this._name
+  }
+}
+
+export default TagReference

--- a/test/Resources/RepositoryBar.js
+++ b/test/Resources/RepositoryBar.js
@@ -1,0 +1,1 @@
+export default class RepositoryBar {}

--- a/test/Resources/RepositoryFoo.js
+++ b/test/Resources/RepositoryFoo.js
@@ -1,0 +1,1 @@
+export default class RepositoryFoo {}

--- a/test/Resources/RepositoryManager.js
+++ b/test/Resources/RepositoryManager.js
@@ -1,0 +1,9 @@
+export default class RepositoryManager {
+  constructor (repositories) {
+    this._repositories = repositories
+  }
+
+  get repositories () {
+    return this._repositories
+  }
+}

--- a/test/Resources/config/tagged-arguments.js
+++ b/test/Resources/config/tagged-arguments.js
@@ -1,0 +1,20 @@
+module.exports = {
+  services: {
+    'repository-manager': {
+      class: './../RepositoryManager',
+      arguments: ['!tagged repository']
+    },
+    'repository-foo': {
+      class: './../RepositoryFoo',
+      tags: [
+        { name: 'repository' }
+      ]
+    },
+    'repository-bar': {
+      class: './../RepositoryBar',
+      tags: [
+        { name: 'repository' }
+      ]
+    }
+  }
+}

--- a/test/Resources/config/tagged-arguments.json
+++ b/test/Resources/config/tagged-arguments.json
@@ -1,0 +1,16 @@
+{
+  "services": {
+    "repository-manager": {
+      "class": "./../RepositoryManager",
+      "arguments": ["!tagged repository"]
+    },
+    "repository-foo": {
+      "class": "./../RepositoryFoo",
+      "tags": [{ "name": "repository" }]
+    },
+    "repository-bar": {
+      "class": "./../RepositoryBar",
+      "tags": [{ "name": "repository" }]
+    }
+  }
+}

--- a/test/Resources/config/tagged-arguments.yml
+++ b/test/Resources/config/tagged-arguments.yml
@@ -1,0 +1,13 @@
+services:
+  repository-manager:
+    class: ./../RepositoryManager
+    arguments: ["!tagged repository"]
+
+  repository-foo:
+    class: ./../RepositoryFoo
+    tags:
+      - { name: repository }
+  repository-bar:
+    class: ./../RepositoryBar
+    tags:
+      - { name: repository }

--- a/test/node-dependency-injection/lib/Loader/JsFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/JsFileLoader.spec.js
@@ -6,6 +6,9 @@ import Foo from '../../../Resources/foo'
 import Bar from '../../../Resources/bar'
 import FooBar from '../../../Resources/foobar'
 import path from 'path'
+import RepositoryManager from '../../../Resources/RepositoryManager'
+import RepositoryFoo from '../../../Resources/RepositoryFoo'
+import RepositoryBar from '../../../Resources/RepositoryBar'
 
 const assert = chai.assert
 
@@ -111,6 +114,34 @@ describe('JsFileLoader', () => {
       // Assert.
       assert.instanceOf(bar, FooBar)
       return assert.instanceOf(baz, FooBar)
+    })
+  })
+
+  describe('load with tags', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      loader = new JsFileLoader(container)
+      container.compile()
+    })
+
+    it('should load instance of service with tagged arguments', () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/tagged-arguments.js'
+      )
+
+      // Act.
+      loader.load(configPath)
+      const repositoryManager = container.get('repository-manager')
+      const repositoryFoo = container.get('repository-foo')
+      const repositoryBar = container.get('repository-bar')
+
+      // Assert.
+      assert.instanceOf(repositoryManager, RepositoryManager)
+      assert.instanceOf(repositoryFoo, RepositoryFoo)
+      assert.instanceOf(repositoryBar, RepositoryBar)
+      assert.equal(repositoryManager.repositories.length, 2)
     })
   })
 })

--- a/test/node-dependency-injection/lib/Loader/JsonFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/JsonFileLoader.spec.js
@@ -6,6 +6,9 @@ import Foo from '../../../Resources/foo'
 import Bar from '../../../Resources/bar'
 import FooBar from '../../../Resources/foobar'
 import path from 'path'
+import RepositoryManager from '../../../Resources/RepositoryManager'
+import RepositoryFoo from '../../../Resources/RepositoryFoo'
+import RepositoryBar from '../../../Resources/RepositoryBar'
 
 const assert = chai.assert
 
@@ -114,6 +117,34 @@ describe('JsonFileLoader', () => {
       // Assert.
       assert.instanceOf(bar, FooBar)
       return assert.instanceOf(baz, FooBar)
+    })
+  })
+
+  describe('load with tags', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      loader = new JsonFileLoader(container)
+      container.compile()
+    })
+
+    it('should load instance of service with tagged arguments', () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/tagged-arguments.json'
+      )
+
+      // Act.
+      loader.load(configPath)
+      const repositoryManager = container.get('repository-manager')
+      const repositoryFoo = container.get('repository-foo')
+      const repositoryBar = container.get('repository-bar')
+
+      // Assert.
+      assert.instanceOf(repositoryManager, RepositoryManager)
+      assert.instanceOf(repositoryFoo, RepositoryFoo)
+      assert.instanceOf(repositoryBar, RepositoryBar)
+      assert.equal(repositoryManager.repositories.length, 2)
     })
   })
 })

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -17,6 +17,9 @@ import ChildClass from '../../../Resources/abstract/ChildClass'
 import Service from '../../../Resources/abstract/Service'
 import { ClassOne, ClassTwo } from '../../../Resources/multipleExports'
 import { NamedService } from '../../../Resources/NamedService'
+import RepositoryManager from '../../../Resources/RepositoryManager'
+import RepositoryFoo from '../../../Resources/RepositoryFoo'
+import RepositoryBar from '../../../Resources/RepositoryBar'
 
 const assert = chai.assert
 
@@ -343,6 +346,34 @@ describe('YamlFileLoader', () => {
       // Assert.
       assert.instanceOf(one, ClassOne)
       return assert.instanceOf(two, ClassTwo)
+    })
+  })
+
+  describe('load with tags', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      loader = new YamlFileLoader(container)
+      container.compile()
+    })
+
+    it('should load instance of service with tagged arguments', () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/tagged-arguments.yml'
+      )
+
+      // Act.
+      loader.load(configPath)
+      const repositoryManager = container.get('repository-manager')
+      const repositoryFoo = container.get('repository-foo')
+      const repositoryBar = container.get('repository-bar')
+
+      // Assert.
+      assert.instanceOf(repositoryManager, RepositoryManager)
+      assert.instanceOf(repositoryFoo, RepositoryFoo)
+      assert.instanceOf(repositoryBar, RepositoryBar)
+      assert.equal(repositoryManager.repositories.length, 2)
     })
   })
 })

--- a/test/node-dependency-injection/lib/TagReference.spec.js
+++ b/test/node-dependency-injection/lib/TagReference.spec.js
@@ -1,0 +1,20 @@
+import { describe, it } from 'mocha'
+import chai from 'chai'
+import TagReference from '../../../lib/TagReference'
+
+const assert = chai.assert
+
+describe('TagReference', () => {
+  describe('name', () => {
+    it('should get the right constructor name', () => {
+      // Arrange.
+      const name = 'foobar'
+
+      // Act.
+      const actual = new TagReference(name)
+
+      // Assert.
+      assert.strictEqual(actual.name, name)
+    })
+  })
+})


### PR DESCRIPTION
Following the same approach as Symfony, this PR aims to add support for defining the arguments of the services using tags. This is very useful for situations like the showed below, initializing server components, such as repositories, controllers, etc.

```yaml
services:
  repository-manager:
    class: ./../RepositoryManager
    arguments: ["!tagged repository"]

  repository-foo:
    class: ./../RepositoryFoo
    tags:
      - { name: repository }
  repository-bar:
    class: ./../RepositoryBar
    tags:
      - { name: repository }
```