### PR TITLE
Prioritize named exports over default export

### DIFF
--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -275,9 +275,12 @@ class FileLoader {
     let fromDirectory = (!path.isAbsolute(classObject)) ? path.dirname(
       this.filePath) : '/'
     fromDirectory = this.container.defaultDir || fromDirectory
-    const className = mainClassName || path.basename(classObject)
     const exportedModule = require(path.join(fromDirectory, classObject))
-    return exportedModule[className] || exportedModule.default
+
+    const mainClass = exportedModule[mainClassName]
+    const defaultClass = exportedModule.default
+    const fileNameClass = exportedModule[path.basename(classObject)]
+    return mainClass || defaultClass || fileNameClass
   }
 }
 

--- a/test/Resources/MultipleExports.js
+++ b/test/Resources/MultipleExports.js
@@ -1,5 +1,5 @@
-export class ClassOne { }
+export class ClassOne {}
 
-export class ClassTwo { }
+export class ClassTwo {}
 
-export default class ClassThree {}
+export class MultipleExports {}

--- a/test/Resources/MultipleExportsWithDefault.js
+++ b/test/Resources/MultipleExportsWithDefault.js
@@ -1,0 +1,7 @@
+export class ClassOne {}
+
+export class ClassTwo {}
+
+export class MultipleExportsWithDefault {}
+
+export default class DefaultClass {}

--- a/test/Resources/config/main.yml
+++ b/test/Resources/config/main.yml
@@ -1,9 +1,11 @@
 services:
-  one:
+  classOne:
     class: ./../MultipleExports
     main: ClassOne
-  two:
+  classTwo:
     class: ./../MultipleExports
     main: ClassTwo
-  three:
+  multipleExports:
     class: ./../MultipleExports
+  defaultClass:
+    class: ./../MultipleExportsWithDefault

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -15,7 +15,8 @@ import Mailer from '../../../Resources/Mailer'
 import DecoratingMailerTwo from '../../../Resources/DecoratingMailerTwo'
 import ChildClass from '../../../Resources/abstract/ChildClass'
 import Service from '../../../Resources/abstract/Service'
-import ClassThree, { ClassOne, ClassTwo } from '../../../Resources/MultipleExports'
+import { MultipleExports, ClassOne, ClassTwo } from '../../../Resources/MultipleExports'
+import DefaultClass from '../../../Resources/MultipleExportsWithDefault'
 import { NamedService } from '../../../Resources/NamedService'
 import RepositoryManager from '../../../Resources/RepositoryManager'
 import RepositoryFoo from '../../../Resources/RepositoryFoo'
@@ -342,14 +343,16 @@ describe('YamlFileLoader', () => {
 
       // Act.
       loader.load(configPath)
-      const one = container.get('one')
-      const two = container.get('two')
-      const three = container.get('three')
+      const one = container.get('classOne')
+      const two = container.get('classTwo')
+      const multipleExports = container.get('multipleExports')
+      const defaultClass = container.get('defaultClass')
 
       // Assert.
       assert.instanceOf(one, ClassOne)
       assert.instanceOf(two, ClassTwo)
-      return assert.instanceOf(three, ClassThree)
+      assert.instanceOf(defaultClass, DefaultClass)
+      return assert.instanceOf(multipleExports, MultipleExports)
     })
   })
 


### PR DESCRIPTION
For definitions that contain the property `main`, the named export that indicates this main should be prioritized over the default export that the file could contain.

For instance, a file that contains two exports:

```js
export class ClassNamed { }

export default class ClassDefault {}
```

A definition that uses the `ClassTwo`: 

```yaml
  two:
    class: ./../MultipleExports
    main: ClassNamed
```

Will end up getting an instance of `ClassDefault` as the `default` export has priority over any named export, even when the `main`  property has been set.