### PR TITLE
Fixing module.exports = Class

### DIFF
--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -280,7 +280,7 @@ class FileLoader {
     const mainClass = exportedModule[mainClassName]
     const defaultClass = exportedModule.default
     const fileNameClass = exportedModule[path.basename(classObject)]
-    return mainClass || defaultClass || fileNameClass
+    return mainClass || defaultClass || fileNameClass || exportedModule
   }
 }
 


### PR DESCRIPTION
I got a problem when I have in my node project old module.exports.

class ABC {
   doSomething() {
   }
}

module.exports = ABC;