### PR TITLE
Extend Argument type

### DIFF
--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -141,6 +141,12 @@ export class Reference {
     readonly nullable: boolean;
 }
 
+export class TagReference {
+    constructor (name: string);
+
+    readonly name: string;
+}
+
 export class PassConfig {
     static readonly TYPE_BEFORE_OPTIMIZATION: PassConfigHook;
     static readonly TYPE_OPTIMIZE: PassConfigHook;

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -4,7 +4,7 @@ export type PassConfigHook = 'beforeOptimization'|'optimize'|'beforeRemoving'|'r
 
 export type Parameter = string|boolean|object|any[];
 
-export type Argument = Reference|PackageReference|any;
+export type Argument = TagReference|Reference|PackageReference|any;
 
 export interface Extension {
     load: Function;


### PR DESCRIPTION
I just missed to extend `Argument`'s type.

Sorry!