### PR TITLE
feat: dynamic eslint import

### DIFF
--- a/lib/Autowire.js
+++ b/lib/Autowire.js
@@ -1,7 +1,6 @@
 import path from 'path'
 import fs from 'fs'
 import json5 from 'json5'
-import { parse } from '@typescript-eslint/typescript-estree'
 import Definition from './Definition'
 import Reference from './Reference'
 import ServiceFile from './ServiceFile'
@@ -153,6 +152,7 @@ export default class Autowire {
    * @private
    */
   async _getClassDeclaration (filePath) {
+    const { parse } = await import('@typescript-eslint/typescript-estree')
     const sourceCode = fs.readFileSync(filePath, 'utf8')
     const body = parse(sourceCode).body
     const classDeclaration = body.find(

--- a/lib/ContainerBuilder.js
+++ b/lib/ContainerBuilder.js
@@ -18,7 +18,7 @@ class ContainerBuilder {
    * @param {boolean} containerReferenceAsService
    * @param {String} defaultDir
    */
-  constructor (containerReferenceAsService = false, defaultDir = null) {
+  constructor (containerReferenceAsService = false, defaultDir = null, importResolver = null) {
     this.ensureIsAbsolute(defaultDir)
     this.ensureDirectoryExists(defaultDir)
     this._definitions = new Map()
@@ -32,6 +32,7 @@ class ContainerBuilder {
     this._instanceManager = undefined
     this._containerReferenceAsService = containerReferenceAsService
     this._defaultDir = defaultDir
+    this._importResolver = importResolver
   }
 
   ensureDirectoryExists (directory) {

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -292,12 +292,13 @@ class FileLoader {
     fromDirectory = this.container.defaultDir || fromDirectory
 
     let exportedModule = null
+    let resolve = this._container.importResolver || require
 
     try {
-      exportedModule = require(path.join(fromDirectory, classObject))
+      exportedModule = resolve(path.join(fromDirectory, classObject))
     } catch (error) {
       if (error.code === 'MODULE_NOT_FOUND' && validate(classObject)) {
-        exportedModule = require(classObject)
+        exportedModule = resolve(classObject)
       } else {
         throw error
       }


### PR DESCRIPTION
First off, great project, love the autowire feature. 

I had some trouble with the static import of `typescript-eslint`, which in turn imports `typescript`, but does not explicitly state a dependency (see https://github.com/typescript-eslint/typescript-eslint/issues/828). This leads to crashes in an environment where the `typescript` package is not explicitly installed (for example in my production environment).

Maybe I just missed something there, otherwise I would propose to import the `typescript-eslint` package dynamically, so it's only loaded when actually doing the autowiring process. This allows to exclude the `typescript` package in builds where you do the autowiring at compile time.