### PR TITLE
Enhancement: Support main property on factory definition

### DIFF
--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -94,7 +94,7 @@ class FileLoader {
     if (service.factory.class.includes('@', 0)) {
       object = new Reference(service.factory.class.slice(1))
     } else {
-      object = this._requireClassNameFromPath(service.factory.class)
+      object = this._requireClassNameFromPath(service.factory.class, service.factory.main)
     }
 
     const definition = new Definition()

--- a/test/Resources-ts/config/main.yml
+++ b/test/Resources-ts/config/main.yml
@@ -9,3 +9,8 @@ services:
     class: ./../MultipleExports
   defaultClass:
     class: ./../MultipleExportsWithDefault
+  kebabCaseFilenameFactory:
+    factory:
+      class: ./../kebab-case-filename-factory
+      main: KebabCaseFilenameFactory
+      method: "create"

--- a/test/Resources-ts/kebab-case-filename-factory.ts
+++ b/test/Resources-ts/kebab-case-filename-factory.ts
@@ -1,0 +1,7 @@
+export class KebabCaseFilenameFactory {
+    static create(){
+        return new KebabCaseFilenameClass();
+    }
+}
+
+export class KebabCaseFilenameClass {}

--- a/test/Resources/config/main.yml
+++ b/test/Resources/config/main.yml
@@ -9,3 +9,8 @@ services:
     class: ./../MultipleExports
   defaultClass:
     class: ./../MultipleExportsWithDefault
+  kebabCaseFilenameFactory:
+    factory:
+      class: ./../kebab-case-filename-factory
+      main: KebabCaseFilenameFactory
+      method: "create"

--- a/test/Resources/kebab-case-filename-factory.js
+++ b/test/Resources/kebab-case-filename-factory.js
@@ -1,0 +1,7 @@
+export class KebabCaseFilenameFactory {
+    static create(){
+        return new KebabCaseFilenameClass();
+    }
+}
+
+export class KebabCaseFilenameClass {}

--- a/test/node-dependency-injection/lib-ts/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib-ts/Loader/YamlFileLoader.spec.js
@@ -355,6 +355,7 @@ describe('YamlFileLoaderTS', () => {
       const two = container.get('classTwo')
       const multipleExports = container.get('multipleExports')
       const defaultClass = container.get('defaultClass')
+      const kebabCaseFilenameFactory = container.get('kebabCaseFilenameFactory')
 
       // Assert.
       assert.instanceOf(one, ClassOne)

--- a/test/node-dependency-injection/lib-ts/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib-ts/Loader/YamlFileLoader.spec.js
@@ -20,6 +20,7 @@ import DecoratingMailerTwo from '../../../Resources-ts/DecoratingMailerTwo'
 import ChildClass from '../../../Resources-ts/abstract/ChildClass'
 import Service from '../../../Resources-ts/abstract/Service'
 import { MultipleExports, ClassOne, ClassTwo } from '../../../Resources-ts/MultipleExports'
+import { KebabCaseFilenameClass } from '../../../Resources-ts/kebab-case-filename-factory'
 import DefaultClass from '../../../Resources-ts/MultipleExportsWithDefault'
 import { NamedService } from '../../../Resources-ts/NamedService'
 import RepositoryManager from '../../../Resources-ts/RepositoryManager'
@@ -359,6 +360,7 @@ describe('YamlFileLoaderTS', () => {
       assert.instanceOf(one, ClassOne)
       assert.instanceOf(two, ClassTwo)
       assert.instanceOf(defaultClass, DefaultClass)
+      assert.instanceOf(kebabCaseFilenameFactory, KebabCaseFilenameClass)
       return assert.instanceOf(multipleExports, MultipleExports)
     })
 

--- a/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/YamlFileLoader.spec.js
@@ -21,6 +21,7 @@ import ChildClass from '../../../Resources/abstract/ChildClass'
 import ChildClassTwo from '../../../Resources/abstract/ChildClassTwo'
 import Service from '../../../Resources/abstract/Service'
 import { MultipleExports, ClassOne, ClassTwo } from '../../../Resources/MultipleExports'
+import { KebabCaseFilenameClass } from '../../../Resources/kebab-case-filename-factory';
 import DefaultClass from '../../../Resources/MultipleExportsWithDefault'
 import { NamedService } from '../../../Resources/NamedService'
 import RepositoryManager from '../../../Resources/RepositoryManager'
@@ -347,11 +348,13 @@ describe('YamlFileLoader', () => {
       const two = container.get('classTwo')
       const multipleExports = container.get('multipleExports')
       const defaultClass = container.get('defaultClass')
+      const kebabCaseFilenameFactory = container.get('kebabCaseFilenameFactory')
 
       // Assert.
       assert.instanceOf(one, ClassOne)
       assert.instanceOf(two, ClassTwo)
       assert.instanceOf(defaultClass, DefaultClass)
+      assert.instanceOf(kebabCaseFilenameFactory, KebabCaseFilenameClass)
       return assert.instanceOf(multipleExports, MultipleExports)
     })
 


### PR DESCRIPTION
The `main` property in a service definition allows to specify a main class into a file specified by a path in the property class. This is helpful when the filename doesn't match with the service class, for example when using kebab-case for filenames.

```yml
Shop.Shared.MongoConfig:
    factory:
      class: ../../../../../contexts/shop/shared/infrastructure/persistence/mongo/mongo-config-factory
      main: MongoConfigFactory
      method: 'createConfig'
```

Factories definitions doesn't handle the main property at the moment so we added the variable as an argument to the `_requireClassNameFromPath` method. Given that the method is already prepared to receive the argument this is a straightforward change.

Related issue: https://github.com/zazoomauro/node-dependency-injection/issues/200

Previous state: 
https://github.com/zazoomauro/node-dependency-injection/blob/cfe270e218d7c6523d08360fc75af5f844687b34/lib/Loader/FileLoader.js#L97


Proposed change:
https://github.com/zazoomauro/node-dependency-injection/blob/46feae5a5e53f43ae25329ddb41a91873732fe12/lib/Loader/FileLoader.js#L97


