### PR TITLE
feat: Add support for named and typed argument injection in Autowire

### DIFF
--- a/lib/Autowire.js
+++ b/lib/Autowire.js
@@ -227,9 +227,14 @@ export default class Autowire {
           ?.typeName
           ?.name
         if (!typeNameForArgument) {
-          this._container.loggerHelper.debug(
-            `Autowire: skipping constructor parameter without type annotation in ${ServiceClass.name}`
-          )
+          const paramName = identifier.name
+          if (paramName && this._container.binds.has(paramName)) {
+            definition.addArgument(this._container.binds.get(paramName), definition.abstract)
+          } else {
+            this._container.loggerHelper.debug(
+              `Autowire: skipping constructor parameter without type annotation in ${ServiceClass.name}`
+            )
+          }
           continue
         }
         const argumentId = await this._getIdentifierFromImports(typeNameForArgument, importMap, parsedFile)

--- a/lib/ContainerBuilder.js
+++ b/lib/ContainerBuilder.js
@@ -38,6 +38,7 @@ class ContainerBuilder {
     this._containerReferenceAsService = containerReferenceAsService
     this._defaultDir = defaultDir
     this._autowire = null
+    this._binds = new Map()
   }
 
   /**
@@ -49,6 +50,14 @@ class ContainerBuilder {
 
   get autowire () {
     return this._autowire
+  }
+
+  get binds () {
+    return this._binds
+  }
+
+  addBind (name, value) {
+    this._binds.set(name, value)
   }
 
   ensureDirectoryExists (directory) {

--- a/lib/Loader/FileLoader.js
+++ b/lib/Loader/FileLoader.js
@@ -188,6 +188,11 @@ class FileLoader {
     } else {
       this._container.defaultDir = defaults.rootDir
     }
+    if (defaults.bind && typeof defaults.bind === 'object') {
+      for (const [name, value] of Object.entries(defaults.bind)) {
+        this._container.addBind(name, new Argument(this._container).parse(value))
+      }
+    }
     const autowire = new Autowire(this._container)
     if (defaults.exclude && Array.isArray(defaults.exclude)) {
       defaults.exclude.forEach(exclude => {

--- a/test/Resources-ts/Autowire/config/services-bind.yaml
+++ b/test/Resources-ts/Autowire/config/services-bind.yaml
@@ -1,0 +1,7 @@
+services:
+  _defaults:
+    autowire: true
+    rootDir: ../src
+    exclude: ["ToExclude"]
+    bind:
+      adminEmail: "manager@example.com"

--- a/test/Resources-ts/Autowire/src/Service/BindService.ts
+++ b/test/Resources-ts/Autowire/src/Service/BindService.ts
@@ -1,0 +1,16 @@
+import Bar from './Bar'
+
+export default class BindService {
+    constructor(
+        private readonly adminEmail: string,
+        private readonly bar: Bar,
+    ) {}
+
+    getAdminEmail(): string {
+        return this.adminEmail
+    }
+
+    async callBarProcessMethod(): Promise<number> {
+        return this.bar.process()
+    }
+}

--- a/test/node-dependency-injection/lib-ts/Autowire.spec.js
+++ b/test/node-dependency-injection/lib-ts/Autowire.spec.js
@@ -621,3 +621,55 @@ describe('AutowireTS', () => {
         assert.strictEqual(value, 10)
     })
 })
+import BindService from '../../Resources-ts/Autowire/src/Service/BindService'
+
+describe('AutowireTS - Bind', () => {
+    const resourcesTsFolder = 'Resources-ts'
+    const autowireFolder = 'Autowire'
+    const dir = path.join(__dirname, '..', '..', resourcesTsFolder, autowireFolder, 'src')
+
+    it('should inject a bound scalar argument by parameter name (programmatic)', async () => {
+        // Arrange.
+        const container = new ContainerBuilder(false, dir)
+        container.addBind('adminEmail', 'manager@example.com')
+        const autowire = new Autowire(container)
+
+        // Act.
+        await autowire.process()
+        await container.compile()
+        const service = container.get(BindService)
+
+        // Assert.
+        assert.instanceOf(service, BindService)
+        assert.strictEqual(service.getAdminEmail(), 'manager@example.com')
+        const value = await service.callBarProcessMethod()
+        assert.strictEqual(value, 10)
+    })
+
+    it('should inject a bound scalar argument via YAML _defaults.bind', async () => {
+        // Arrange.
+        const configFile = path.join(
+            __dirname, '..', '..', resourcesTsFolder, autowireFolder, 'config', 'services-bind.yaml'
+        )
+        const container = new ContainerBuilder(false, dir)
+        const loader = new YamlFileLoader(container)
+
+        // Act.
+        await loader.load(configFile)
+        await container.compile()
+        const service = container.get(BindService)
+
+        // Assert.
+        assert.instanceOf(service, BindService)
+        assert.strictEqual(service.getAdminEmail(), 'manager@example.com')
+    })
+
+    it('should expose binds via container.binds getter', () => {
+        // Arrange.
+        const container = new ContainerBuilder()
+        container.addBind('someParam', 'someValue')
+
+        // Assert.
+        assert.strictEqual(container.binds.get('someParam'), 'someValue')
+    })
+})


### PR DESCRIPTION
Introduce functionality to inject arguments by name and type in the Autowire class, enhancing dependency management. Include tests to validate the new behavior and support for YAML configuration for bound arguments.