### PR TITLE
feat: add XML support for service configuration

### DIFF
--- a/bin/Services/File/XmlAdapter.js
+++ b/bin/Services/File/XmlAdapter.js
@@ -1,0 +1,53 @@
+import BaseAdapter from './BaseAdapter'
+import { XMLBuilder } from 'fast-xml-parser'
+
+export default class XmlAdapter extends BaseAdapter {
+  /**
+   * @return {string}
+   */
+  static get FORMAT () {
+    return 'xml'
+  }
+
+  /**
+   * @return {string}
+   */
+  get defaultConfiguration () {
+    const config = super.defaultConfiguration
+    const builder = new XMLBuilder({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      format: true,
+      indentBy: '    '
+    })
+
+    const serviceNodes = []
+    for (const [id, svc] of Object.entries(config.services)) {
+      const node = { '@_id': id, '@_class': svc.class }
+      if (svc.arguments && svc.arguments.length > 0) {
+        node.argument = svc.arguments.map((arg) => ({ '#text': arg }))
+      }
+      serviceNodes.push(node)
+    }
+
+    const xmlData = {
+      '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' },
+      container: {
+        imports: {
+          import: config.imports.map((imp) => ({ '@_resource': imp.resource }))
+        },
+        parameters: {
+          parameter: Object.entries(config.parameters).map(([key, value]) => ({
+            '@_key': key,
+            '#text': value
+          }))
+        },
+        services: {
+          service: serviceNodes
+        }
+      }
+    }
+
+    return `${builder.build(xmlData)}\n`
+  }
+}

--- a/bin/ndi-container:service.js
+++ b/bin/ndi-container:service.js
@@ -7,8 +7,10 @@ import util from 'util'
 import { ContainerBuilder, YamlFileLoader } from '../lib/'
 import JsAdapter from './Services/File/JsAdapter'
 import JsonAdapter from './Services/File/JsonAdapter'
+import XmlAdapter from './Services/File/XmlAdapter'
 import JsFileLoader from '../lib/Loader/JsFileLoader'
 import JsonFileLoader from '../lib/Loader/JsonFileLoader'
+import XmlFileLoader from '../lib/Loader/XmlFileLoader'
 import 'console.table'
 
 program.arguments('<path> <service>').action((dir, service) => {
@@ -22,6 +24,9 @@ program.arguments('<path> <service>').action((dir, service) => {
       break
     case JsonAdapter.FORMAT:
       loader = new JsonFileLoader(container)
+      break
+    case XmlAdapter.FORMAT:
+      loader = new XmlFileLoader(container)
       break
     default:
       loader = new YamlFileLoader(container)

--- a/lib/Dump/XmlDumper.js
+++ b/lib/Dump/XmlDumper.js
@@ -1,0 +1,59 @@
+import fs from 'fs/promises'
+import { XMLBuilder } from 'fast-xml-parser'
+import Dumper from './Dumper'
+
+export default class XmlDumper extends Dumper {
+  async dump () {
+    const builder = new XMLBuilder({
+      ignoreAttributes: false,
+      attributeNamePrefix: '@_',
+      format: true,
+      indentBy: '    '
+    })
+
+    const xmlData = {
+      '?xml': { '@_version': '1.0', '@_encoding': 'UTF-8' },
+      container: {
+        services: {
+          service: this._buildServiceNodes()
+        }
+      }
+    }
+
+    const dataContent = `${builder.build(xmlData)}\n`
+    await fs.writeFile(this._serviceFile, dataContent, { encoding: 'utf8' })
+  }
+
+  /**
+   * @returns {Array}
+   * @private
+   */
+  _buildServiceNodes () {
+    const nodes = []
+    for (const [id, service] of Object.entries(this._content.services)) {
+      if (typeof service === 'string') {
+        // alias
+        nodes.push({
+          '@_id': id,
+          '@_alias': service.slice(1)
+        })
+      } else {
+        const node = { '@_id': id }
+        if (service.class !== undefined) {
+          node['@_class'] = service.class
+        }
+        if (service.abstract === true) {
+          node['@_abstract'] = 'true'
+        }
+        if (service.parent !== undefined) {
+          node['@_parent'] = service.parent
+        }
+        if (service.arguments && service.arguments.length > 0) {
+          node.argument = service.arguments.map((arg) => ({ '#text': arg }))
+        }
+        nodes.push(node)
+      }
+    }
+    return nodes
+  }
+}

--- a/lib/Loader/XmlFileLoader.js
+++ b/lib/Loader/XmlFileLoader.js
@@ -1,0 +1,329 @@
+import FileLoader from './FileLoader'
+import { XMLParser } from 'fast-xml-parser'
+import * as fs from 'fs/promises'
+import ServiceFileNotFoundException from '../Exception/ServiceFileNotFoundException'
+import ServiceFileNotLoadedException from '../Exception/ServiceFileNotLoadedException'
+
+export default class XmlFileLoader extends FileLoader {
+  /**
+   * @param {string|null} file
+   */
+  async load (file = null) {
+    super.filePath = file
+    this._container.loggerHelper.info(`Loading XML file: ${file}`)
+
+    let rawContent
+
+    try {
+      rawContent = await fs.readFile(this.filePath, 'utf8')
+    } catch (e) {
+      throw new ServiceFileNotFoundException(this.filePath)
+    }
+
+    let parsed
+
+    try {
+      const parser = new XMLParser({
+        ignoreAttributes: false,
+        attributeNamePrefix: '@_',
+        isArray: (name) => ['import', 'service', 'argument', 'tag', 'call', 'property', 'parameter'].includes(name),
+        allowBooleanAttributes: true
+      })
+      parsed = parser.parse(rawContent)
+    } catch (e) {
+      throw new ServiceFileNotLoadedException(e.message)
+    }
+
+    const container = parsed.container || {}
+
+    const imports = this._transformImports(container.imports)
+    const parameters = this._transformParameters(container.parameters)
+    const services = this._transformServices(container.services)
+
+    await this._parseImports(imports)
+    await this._parseParameters(parameters)
+    await this._parseDefinitions(services)
+  }
+
+  /**
+   * @param {*} importsNode
+   * @returns {Array<{resource: string}>}
+   * @private
+   */
+  _transformImports (importsNode) {
+    if (!importsNode || !importsNode.import) {
+      return []
+    }
+    return importsNode.import.map((imp) => ({ resource: imp['@_resource'] }))
+  }
+
+  /**
+   * @param {*} parametersNode
+   * @returns {Object}
+   * @private
+   */
+  _transformParameters (parametersNode) {
+    if (!parametersNode || !parametersNode.parameter) {
+      return {}
+    }
+
+    const result = {}
+    for (const param of parametersNode.parameter) {
+      const key = param['@_key']
+      if (key === undefined) {
+        continue
+      }
+      result[key] = this._parseParameterValue(param)
+    }
+    return result
+  }
+
+  /**
+   * @param {*} param
+   * @returns {*}
+   * @private
+   */
+  _parseParameterValue (param) {
+    const type = param['@_type']
+
+    if (type === 'collection') {
+      // array of items — each child <parameter> has no key
+      return (param.parameter || []).map((p) => this._parseParameterValue(p))
+    }
+
+    if (type === 'map') {
+      // object — each child <parameter> has a key attribute
+      const obj = {}
+      for (const child of (param.parameter || [])) {
+        obj[child['@_key']] = this._parseParameterValue(child)
+      }
+      return obj
+    }
+
+    if (type === 'boolean') {
+      const val = String(param['#text'] ?? param).trim().toLowerCase()
+      return val === 'true'
+    }
+
+    // plain value
+    const raw = param['#text'] ?? param
+    if (raw === undefined || raw === null) {
+      return raw
+    }
+    return String(raw)
+  }
+
+  /**
+   * @param {*} servicesNode
+   * @returns {Object}
+   * @private
+   */
+  _transformServices (servicesNode) {
+    if (!servicesNode) {
+      return {}
+    }
+
+    const result = {}
+
+    // Handle _defaults
+    if (servicesNode.defaults) {
+      result._defaults = this._transformDefaults(servicesNode.defaults)
+    }
+
+    for (const svc of (servicesNode.service || [])) {
+      const id = svc['@_id']
+      if (id === undefined) {
+        continue
+      }
+
+      // Alias
+      if (svc['@_alias'] !== undefined) {
+        result[id] = `@${svc['@_alias']}`
+        continue
+      }
+
+      // Synthetic
+      if (svc['@_synthetic'] === true || svc['@_synthetic'] === 'true') {
+        result[id] = { synthetic: true }
+        continue
+      }
+
+      result[id] = this._transformService(svc)
+    }
+
+    return result
+  }
+
+  /**
+   * @param {*} defaultsNode
+   * @returns {Object}
+   * @private
+   */
+  _transformDefaults (defaultsNode) {
+    const defaults = {}
+
+    if (defaultsNode['@_autowire'] !== undefined) {
+      defaults.autowire = defaultsNode['@_autowire'] === 'true' || defaultsNode['@_autowire'] === true
+    }
+    if (defaultsNode['@_dir'] !== undefined) {
+      defaults.rootDir = defaultsNode['@_dir']
+    }
+
+    if (defaultsNode.bind) {
+      const binds = Array.isArray(defaultsNode.bind) ? defaultsNode.bind : [defaultsNode.bind]
+      defaults.bind = {}
+      for (const b of binds) {
+        defaults.bind[b['@_prefix']] = b['@_path']
+      }
+    }
+
+    if (defaultsNode.exclude) {
+      const excludes = Array.isArray(defaultsNode.exclude) ? defaultsNode.exclude : [defaultsNode.exclude]
+      defaults.exclude = excludes.map((e) => e['@_pattern'] || e)
+    }
+
+    return defaults
+  }
+
+  /**
+   * @param {*} svc
+   * @returns {Object}
+   * @private
+   */
+  _transformService (svc) {
+    const service = {}
+
+    if (svc['@_class'] !== undefined) {
+      service.class = svc['@_class']
+    }
+    if (svc['@_main'] !== undefined) {
+      service.main = svc['@_main']
+    }
+    if (svc['@_lazy'] !== undefined) {
+      service.lazy = svc['@_lazy'] === 'true' || svc['@_lazy'] === true
+    }
+    if (svc['@_public'] !== undefined) {
+      service.public = svc['@_public'] !== 'false' && svc['@_public'] !== false
+    }
+    if (svc['@_shared'] !== undefined) {
+      service.shared = svc['@_shared'] !== 'false' && svc['@_shared'] !== false
+    }
+    if (svc['@_abstract'] !== undefined) {
+      service.abstract = svc['@_abstract'] === 'true' || svc['@_abstract'] === true
+    }
+    if (svc['@_parent'] !== undefined) {
+      service.parent = svc['@_parent']
+    }
+    if (svc['@_decorates'] !== undefined) {
+      service.decorates = svc['@_decorates']
+    }
+    if (svc['@_decoration-priority'] !== undefined) {
+      service.decoration_priority = Number(svc['@_decoration-priority'])
+    }
+    if (svc['@_deprecated'] !== undefined) {
+      service.deprecated = svc['@_deprecated']
+    }
+
+    service.arguments = this._transformArguments(svc.argument)
+    service.tags = this._transformTags(svc.tag)
+    service.calls = this._transformCalls(svc.call)
+    service.properties = this._transformProperties(svc.property)
+
+    // Factory
+    if (svc.factory) {
+      service.factory = {}
+      const factoryClass = svc.factory['@_class'] ?? svc.factory['@_service']
+      if (factoryClass !== undefined) {
+        service.factory.class = factoryClass
+      }
+      if (svc.factory['@_method'] !== undefined) {
+        service.factory.method = svc.factory['@_method']
+      }
+      if (svc.factory['@_main'] !== undefined) {
+        service.factory.main = svc.factory['@_main']
+      }
+    }
+
+    return service
+  }
+
+  /**
+   * @param {Array|undefined} argNodes
+   * @returns {Array}
+   * @private
+   */
+  _transformArguments (argNodes) {
+    if (!argNodes || argNodes.length === 0) {
+      return []
+    }
+    return argNodes.map((arg) => {
+      const type = arg['@_type']
+      if (type === 'tagged') {
+        return `!tagged ${arg['#text'] ?? arg}`
+      }
+      if (type === 'boolean') {
+        const val = String(arg['#text'] ?? arg).trim().toLowerCase()
+        return val === 'true'
+      }
+      const raw = arg['#text'] ?? arg
+      return raw === undefined || raw === null ? '' : String(raw)
+    })
+  }
+
+  /**
+   * @param {Array|undefined} tagNodes
+   * @returns {Array}
+   * @private
+   */
+  _transformTags (tagNodes) {
+    if (!tagNodes || tagNodes.length === 0) {
+      return []
+    }
+    return tagNodes.map((tag) => {
+      const name = tag['@_name']
+      // All attributes except @_name become tag attributes
+      const attributes = {}
+      for (const key of Object.keys(tag)) {
+        if (key !== '@_name' && key.startsWith('@_')) {
+          attributes[key.slice(2)] = tag[key]
+        }
+      }
+      const result = { name }
+      if (Object.keys(attributes).length > 0) {
+        result.attributes = attributes
+      }
+      return result
+    })
+  }
+
+  /**
+   * @param {Array|undefined} callNodes
+   * @returns {Array}
+   * @private
+   */
+  _transformCalls (callNodes) {
+    if (!callNodes || callNodes.length === 0) {
+      return []
+    }
+    return callNodes.map((call) => ({
+      method: call['@_method'],
+      arguments: this._transformArguments(call.argument)
+    }))
+  }
+
+  /**
+   * @param {Array|undefined} propertyNodes
+   * @returns {Object}
+   * @private
+   */
+  _transformProperties (propertyNodes) {
+    if (!propertyNodes || propertyNodes.length === 0) {
+      return {}
+    }
+    const result = {}
+    for (const prop of propertyNodes) {
+      result[prop['@_name']] = String(prop['#text'] ?? prop)
+    }
+    return result
+  }
+}

--- a/lib/ServiceFile.js
+++ b/lib/ServiceFile.js
@@ -4,6 +4,7 @@ import ServiceFileNotValidExtension from './Exception/ServiceFileNotValidExtensi
 import YamlDumper from './Dump/YamlDumper'
 import JsonDumper from './Dump/JsonDumper'
 import JsDumper from './Dump/JsDumper'
+import XmlDumper from './Dump/XmlDumper'
 import AutowireIdentifier from './AutowireIdentifier'
 
 export default class ServiceFile {
@@ -11,7 +12,7 @@ export default class ServiceFile {
     servicesDumpPath,
     absolutePath = false
   ) {
-    this.validExtensions = ['.yaml', '.yml', '.json', '.js']
+    this.validExtensions = ['.yaml', '.yml', '.json', '.js', '.xml']
     this._ensureAbsolutePathIsValid(servicesDumpPath)
     this._servicesDumpPath = servicesDumpPath
     this._absolutePath = absolutePath
@@ -34,6 +35,10 @@ export default class ServiceFile {
 
     if (['.js'].includes(parsed.ext)) {
       return new JsDumper(this._servicesDumpPath, this._content)
+    }
+
+    if (['.xml'].includes(parsed.ext)) {
+      return new XmlDumper(this._servicesDumpPath, this._content)
     }
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,7 @@ import ContainerBuilder from './ContainerBuilder'
 import JsFileLoader from './Loader/JsFileLoader'
 import JsonFileLoader from './Loader/JsonFileLoader'
 import YamlFileLoader from './Loader/YamlFileLoader'
+import XmlFileLoader from './Loader/XmlFileLoader'
 import PackageReference from './PackageReference'
 import Reference from './Reference'
 import PassConfig from './PassConfig'
@@ -15,6 +16,7 @@ export {
   JsFileLoader,
   JsonFileLoader,
   YamlFileLoader,
+  XmlFileLoader,
   PackageReference,
   TagReference,
   Reference,

--- a/lib/schema/services.xsd
+++ b/lib/schema/services.xsd
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
+
+  <!-- Root element -->
+  <xs:element name="container">
+    <xs:complexType>
+      <xs:all>
+        <xs:element name="imports"    type="importsType"    minOccurs="0"/>
+        <xs:element name="parameters" type="parametersType" minOccurs="0"/>
+        <xs:element name="services"   type="servicesType"   minOccurs="0"/>
+      </xs:all>
+    </xs:complexType>
+  </xs:element>
+
+  <!-- ==================== imports ==================== -->
+  <xs:complexType name="importsType">
+    <xs:sequence>
+      <xs:element name="import" type="importType" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="importType">
+    <xs:attribute name="resource" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- ==================== parameters ==================== -->
+  <xs:complexType name="parametersType">
+    <xs:sequence>
+      <xs:element name="parameter" type="parameterType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!--
+    A parameter can be:
+      - scalar   : <parameter key="name">value</parameter>
+      - boolean  : <parameter key="name" type="boolean">true</parameter>
+      - collection: <parameter key="name" type="collection">
+                      <parameter>item1</parameter>
+                      <parameter>item2</parameter>
+                    </parameter>
+      - map       : <parameter key="name" type="map">
+                      <parameter key="k">v</parameter>
+                    </parameter>
+  -->
+  <xs:complexType name="parameterType" mixed="true">
+    <xs:sequence>
+      <xs:element name="parameter" type="parameterType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="key"  type="xs:string"/>
+    <xs:attribute name="type">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="collection"/>
+          <xs:enumeration value="map"/>
+          <xs:enumeration value="boolean"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <!-- ==================== services ==================== -->
+  <xs:complexType name="servicesType">
+    <xs:sequence>
+      <xs:element name="defaults" type="defaultsType" minOccurs="0"/>
+      <xs:element name="service"  type="serviceType"  minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <!-- _defaults / autowire -->
+  <xs:complexType name="defaultsType">
+    <xs:sequence>
+      <xs:element name="bind"    type="bindType"    minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="exclude" type="excludeType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="autowire" type="xs:boolean"/>
+    <xs:attribute name="dir"      type="xs:string"/>
+  </xs:complexType>
+
+  <xs:complexType name="bindType">
+    <xs:attribute name="prefix" type="xs:string" use="required"/>
+    <xs:attribute name="path"   type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <xs:complexType name="excludeType">
+    <xs:attribute name="pattern" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- service -->
+  <xs:complexType name="serviceType">
+    <xs:all>
+      <xs:element name="argument" type="argumentType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="tag"      type="tagType"      minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="call"     type="callType"     minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="property" type="propertyType" minOccurs="0" maxOccurs="unbounded"/>
+      <xs:element name="factory"  type="factoryType"  minOccurs="0"/>
+    </xs:all>
+    <!-- identity -->
+    <xs:attribute name="id"    type="xs:string" use="required"/>
+    <xs:attribute name="class" type="xs:string"/>
+    <xs:attribute name="alias" type="xs:string"/>
+    <xs:attribute name="main"  type="xs:string"/>
+    <!-- behaviour flags -->
+    <xs:attribute name="lazy"       type="xs:boolean"/>
+    <xs:attribute name="public"     type="xs:boolean"/>
+    <xs:attribute name="shared"     type="xs:boolean"/>
+    <xs:attribute name="abstract"   type="xs:boolean"/>
+    <xs:attribute name="synthetic"  type="xs:boolean"/>
+    <xs:attribute name="parent"     type="xs:string"/>
+    <!-- decoration -->
+    <xs:attribute name="decorates"          type="xs:string"/>
+    <xs:attribute name="decoration-priority" type="xs:integer"/>
+    <!-- deprecation -->
+    <xs:attribute name="deprecated" type="xs:string"/>
+  </xs:complexType>
+
+  <!--
+    Argument values follow the same conventions as YAML/JSON loaders:
+      @serviceId         → Reference
+      @?serviceId        → Nullable Reference
+      %paramName%        → Parameter
+      %env(VAR_NAME)%    → Environment variable
+      !tagged tagName    → Tagged argument (set type="tagged")
+  -->
+  <xs:complexType name="argumentType" mixed="true">
+    <xs:attribute name="type">
+      <xs:simpleType>
+        <xs:restriction base="xs:string">
+          <xs:enumeration value="tagged"/>
+        </xs:restriction>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:complexType>
+
+  <!-- tag -->
+  <xs:complexType name="tagType">
+    <xs:anyAttribute processContents="lax"/>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- call -->
+  <xs:complexType name="callType">
+    <xs:sequence>
+      <xs:element name="argument" type="argumentType" minOccurs="0" maxOccurs="unbounded"/>
+    </xs:sequence>
+    <xs:attribute name="method" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- property -->
+  <xs:complexType name="propertyType" mixed="true">
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
+
+  <!-- factory -->
+  <xs:complexType name="factoryType">
+    <!-- Use 'class' for a class path or 'service' for a service reference (@svcId) -->
+    <xs:attribute name="class"   type="xs:string"/>
+    <xs:attribute name="service" type="xs:string"/>
+    <xs:attribute name="method"  type="xs:string" use="required"/>
+    <xs:attribute name="main"    type="xs:string"/>
+  </xs:complexType>
+
+</xs:schema>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-dependency-injection",
-  "version": "3.2.6",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "node-dependency-injection",
-      "version": "3.2.6",
+      "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.10",
@@ -14,6 +14,7 @@
         "chalk": "^4.1.0",
         "commander": "^8.3.0",
         "console.table": "^0.10.0",
+        "fast-xml-parser": "^5.7.3",
         "js-yaml": "^4.1.1",
         "json5": "^2.2.2",
         "validate-npm-package-name": "^3.0.0"
@@ -2167,6 +2168,18 @@
       "integrity": "sha512-s88O1aVtXftvp5bCPB7WnmXc5IwOZZ7YPuwNPt+GtOOXpPvad1LfbmjYv+qII7zP6RU2QGnqve27dnLycEnyEQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4430,6 +4443,42 @@
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
       "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
       "dev": true
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.8.tgz",
+      "integrity": "sha512-sDVBc2gg8pSKvcbE8rBmOyjSGQf0AdsbqvHeIOv3D/uYNoV4eCReQXyDF8Pdv8+m1FHazACypSz2hR7O2S1LLw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -6871,6 +6920,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -8667,6 +8731,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chalk": "^4.1.0",
     "commander": "^8.3.0",
     "console.table": "^0.10.0",
+    "fast-xml-parser": "^5.7.3",
     "js-yaml": "^4.1.1",
     "json5": "^2.2.2",
     "validate-npm-package-name": "^3.0.0"

--- a/test/Resources/config/fake-import-subfolder.xml
+++ b/test/Resources/config/fake-import-subfolder.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <imports>
+        <import resource="./foo/bar.xml"/>
+        <import resource="./foo/baz.xml"/>
+    </imports>
+</container>

--- a/test/Resources/config/fake-imports.xml
+++ b/test/Resources/config/fake-imports.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <imports>
+        <import resource="./fake-services.xml"/>
+        <import resource="./fake-services-2.xml"/>
+    </imports>
+</container>

--- a/test/Resources/config/fake-services-2.xml
+++ b/test/Resources/config/fake-services-2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="foo_manager" class="./../fooManager"/>
+
+        <service id="bar_manager" class="./../barManager">
+            <argument>@foo_manager</argument>
+        </service>
+    </services>
+</container>

--- a/test/Resources/config/fake-services.xml
+++ b/test/Resources/config/fake-services.xml
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <parameters>
+        <parameter key="fooParameter">barValue</parameter>
+        <parameter key="barParameter" type="collection">
+            <parameter>foo</parameter>
+            <parameter>bar</parameter>
+        </parameter>
+        <parameter key="fooProperty">fooProperty</parameter>
+        <parameter key="param_false" type="boolean">false</parameter>
+        <parameter key="param_object" type="map">
+            <parameter key="foo">bar</parameter>
+            <parameter key="bar">foo</parameter>
+        </parameter>
+    </parameters>
+
+    <services>
+        <service id="foo" class="./../foo">
+            <argument>@bar</argument>
+            <argument>%fs</argument>
+            <argument>foo-bar</argument>
+            <argument>%fooParameter%</argument>
+            <argument>%env(NODE_ENV)%</argument>
+            <tag name="fooTag"/>
+            <property name="property">%fooProperty%</property>
+        </service>
+
+        <service id="bar" class="./../bar">
+            <call method="setFooBar">
+                <argument>@foobar</argument>
+            </call>
+            <tag name="fooTag"/>
+        </service>
+
+        <service id="foobar" class="./../foobar" deprecated="Deprecated service">
+            <argument>@injected.lazy.service</argument>
+        </service>
+
+        <service id="f" alias="foo"/>
+
+        <service id="lazy.service" class="./../foobar" lazy="true"/>
+
+        <service id="injected.lazy.service" class="./../foobar" lazy="true"/>
+
+        <service id="factory" class="./../factory"/>
+
+        <service id="from_factory_without_args">
+            <factory class="./../factory" method="getFactoryWithoutArgs"/>
+        </service>
+
+        <service id="from_factory_with_args">
+            <argument>ok</argument>
+            <factory class="./../factory" method="getFactoryWithArgs"/>
+        </service>
+
+        <service id="from_factory_with_reference_without_args">
+            <factory service="@factory" method="getFactoryWithoutArgs"/>
+        </service>
+
+        <service id="from_factory_with_reference_with_args">
+            <argument>ok</argument>
+            <factory service="@factory" method="getFactoryWithArgs"/>
+        </service>
+
+        <service id="from_factory_with_reference_with_service_arg">
+            <argument>@f</argument>
+            <factory service="@factory" method="getFactoryWithServiceArg"/>
+        </service>
+
+        <service id="service_missing_dependencies" class="./../missingDependencies">
+            <argument>@f</argument>
+            <argument>@?not_exists</argument>
+        </service>
+
+        <service id="service_with_dependencies" class="./../missingDependencies">
+            <argument>@f</argument>
+            <argument>@?foobar</argument>
+        </service>
+
+        <service id="service_missing_dependencies_call" class="./../missingDependencies">
+            <call method="setMethod">
+                <argument>@?not_exists</argument>
+            </call>
+        </service>
+
+        <service id="service_with_dependencies_call" class="./../missingDependencies">
+            <call method="setMethod">
+                <argument>@foobar</argument>
+            </call>
+        </service>
+
+        <service id="foo_with_true" class="./../foo">
+            <argument>@bar</argument>
+            <argument>%fs</argument>
+            <argument type="boolean">true</argument>
+            <argument>%true%</argument>
+        </service>
+
+        <service id="foo_with_false" class="./../foo">
+            <argument>@bar</argument>
+            <argument>%fs%</argument>
+            <argument>not</argument>
+            <argument>%param_false%</argument>
+        </service>
+
+        <service id="private_service" class="./../foo" public="false">
+            <argument>@bar</argument>
+            <argument>%fs%</argument>
+        </service>
+
+        <service id="service_using_private_service" class="./../foo">
+            <argument>@private_service</argument>
+        </service>
+
+        <service id="synthetic_service" synthetic="true"/>
+
+        <service id="app.listener" class="./../listener">
+            <tag name="listener" event="postUpdate"/>
+        </service>
+
+        <service id="app.mailer" class="./../Mailer"/>
+
+        <service id="app.decorating_mailer" class="./../DecoratingMailer" decorates="app.mailer" public="false">
+            <argument>@app.decorating_mailer.inner</argument>
+        </service>
+
+        <service id="service_with_object_parameter" class="./../barManager">
+            <argument>%param_object%</argument>
+        </service>
+
+        <service id="not_shared_service" class="./../Mailer" shared="false"/>
+
+        <service id="decorate.app.mailer" class="./../Mailer"/>
+
+        <service id="decorate.one" class="./../DecoratingMailerOne" decorates="decorate.app.mailer" decoration-priority="3">
+            <argument>@decorate.one.inner</argument>
+        </service>
+
+        <service id="decorate.two" class="./../DecoratingMailerTwo" decorates="decorate.app.mailer" decoration-priority="1">
+            <argument>@decorate.two.inner</argument>
+        </service>
+    </services>
+</container>

--- a/test/Resources/config/foo/bar.xml
+++ b/test/Resources/config/foo/bar.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="bar" class="./../../foobar"/>
+    </services>
+</container>

--- a/test/Resources/config/foo/baz.xml
+++ b/test/Resources/config/foo/baz.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="baz" class="./../../foobar"/>
+    </services>
+</container>

--- a/test/Resources/config/invalid-xml-syntax.xml
+++ b/test/Resources/config/invalid-xml-syntax.xml
@@ -1,0 +1,1 @@
+this is not valid xml <unclosed

--- a/test/Resources/config/main.xml
+++ b/test/Resources/config/main.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="classOne" class="./../MultipleExports" main="ClassOne"/>
+        <service id="classTwo" class="./../MultipleExports" main="ClassTwo"/>
+        <service id="multipleExports" class="./../MultipleExports"/>
+        <service id="defaultClass" class="./../MultipleExportsWithDefault"/>
+        <service id="kebabCaseFilenameFactory">
+            <factory class="./../kebab-case-filename-factory" main="KebabCaseFilenameFactory" method="create"/>
+        </service>
+    </services>
+</container>

--- a/test/Resources/config/named-service.xml
+++ b/test/Resources/config/named-service.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="named" class="./../NamedService"/>
+    </services>
+</container>

--- a/test/Resources/config/service_from_package.xml
+++ b/test/Resources/config/service_from_package.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="foo_emitter" class="events" main="EventEmitter"/>
+    </services>
+</container>

--- a/test/Resources/config/tagged-arguments.xml
+++ b/test/Resources/config/tagged-arguments.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container>
+    <services>
+        <service id="repository-manager" class="./../RepositoryManager">
+            <argument type="tagged">repository</argument>
+        </service>
+
+        <service id="repository-foo" class="./../RepositoryFoo">
+            <tag name="repository"/>
+        </service>
+
+        <service id="repository-bar" class="./../RepositoryBar">
+            <tag name="repository"/>
+        </service>
+    </services>
+</container>

--- a/test/node-dependency-injection/lib/Loader/XmlFileLoader.spec.js
+++ b/test/node-dependency-injection/lib/Loader/XmlFileLoader.spec.js
@@ -1,0 +1,302 @@
+import { describe, it, beforeEach } from 'mocha'
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised';
+chai.use(chaiAsPromised);
+import chaiIterator from 'chai-iterator';
+chai.use(chaiIterator);
+import XmlFileLoader from '../../../../lib/Loader/XmlFileLoader'
+import ContainerBuilder from '../../../../lib/ContainerBuilder'
+import Foo from '../../../Resources/foo'
+import FooManager from '../../../Resources/fooManager'
+import Bar from '../../../Resources/bar'
+import FooBar from '../../../Resources/foobar'
+import path from 'path'
+import MissingDependencies from '../../../Resources/missingDependencies'
+import SyntheticService from '../../../Resources/syntheticService'
+import Listener from '../../../Resources/listener'
+import DecoratingMailer from '../../../Resources/DecoratingMailer'
+import Mailer from '../../../Resources/Mailer'
+import DecoratingMailerTwo from '../../../Resources/DecoratingMailerTwo'
+import ChildClass from '../../../Resources/abstract/ChildClass'
+import { MultipleExports, ClassOne, ClassTwo } from '../../../Resources/MultipleExports'
+import { KebabCaseFilenameClass } from '../../../Resources/kebab-case-filename-factory';
+import DefaultClass from '../../../Resources/MultipleExportsWithDefault'
+import { NamedService } from '../../../Resources/NamedService'
+import RepositoryManager from '../../../Resources/RepositoryManager'
+import RepositoryFoo from '../../../Resources/RepositoryFoo'
+import RepositoryBar from '../../../Resources/RepositoryBar'
+import EventEmitter from 'events'
+
+const assert = chai.assert
+
+describe('XmlFileLoader', () => {
+  let loader
+  let container
+  const logger = { warn: () => { } }
+
+  describe('load', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      container.logger = logger
+      loader = new XmlFileLoader(container)
+    })
+
+    it('should throw an exception if the xml file not exists', async () => {
+      // Arrange.
+      const file = 'fake-filePath.xml'
+
+      // Act.
+      const actual = loader.load(file)
+
+      // Assert.
+      return assert.isRejected(actual, Error, `Service file ${file} not found`)
+    })
+
+    it('should throw an exception if the xml file had invalid syntax', async () => {
+      const actual = loader.load(
+        path.join(__dirname,
+          '/../../../Resources/config/invalid-xml-syntax.xml')
+      )
+
+      return assert.isRejected(actual, Error, /^Service file could not be loaded\. /)
+    })
+
+    it('should load a simple container', async () => {
+      // Arrange.
+      const serviceName = 'foo'
+      const aliasName = 'f'
+      const tagName = 'fooTag'
+      const stringParameterName = 'fooParameter'
+      const stringExpectedParameter = 'barValue'
+      const arrayParameterName = 'barParameter'
+      const stringPropertyExpected = 'fooProperty'
+      const envVariableExpected = 'test'
+
+      // Act.
+      await loader.load(
+        path.join(__dirname, '..', '/../../Resources/config/fake-services.xml'))
+      await container.compile()
+      const service = container.get(serviceName)
+      const aliasService = container.get(aliasName)
+      const taggedServices = container.findTaggedServiceIds(tagName)
+      const stringActualParameter = container.getParameter(stringParameterName)
+      const arrayActualParameter = container.getParameter(arrayParameterName)
+      const fromFactoryWithoutArgs = container.get('from_factory_without_args')
+      const fromFactoryWithArgs = container.get('from_factory_with_args')
+      const fromFactoryWithReferenceWithoutArgs = container.get(
+        'from_factory_with_reference_without_args')
+      const fromFactoryWithReferenceWithArgs = container.get(
+        'from_factory_with_reference_with_args')
+      const fromFactoryWithReferenceWithServiceArg = container.get(
+        'from_factory_with_reference_with_service_arg')
+      const serviceMissingDependencies = container.get(
+        'service_missing_dependencies')
+      const serviceWithDependencies = container.get('service_with_dependencies')
+      const serviceMissingDependenciesCall = container.get(
+        'service_missing_dependencies_call')
+      const serviceWithDependenciesCall = container.get(
+        'service_with_dependencies_call')
+      const fooWithTrue = container.get('foo_with_true')
+      const fooWithFalse = container.get('foo_with_false')
+      const throwPrivateServiceException = () => container.get('private_service')
+      const serviceUsingPrivateService = container.get(
+        'service_using_private_service')
+      const listener = container.get('app.listener')
+      const mailer = container.get('app.mailer')
+      const mailerInner = container.get('app.decorating_mailer.inner')
+      const serviceWithObjectParameter = container.get(
+        'service_with_object_parameter')
+      const decorateAppMailer = container.get('decorate.app.mailer')
+
+      // Assert.
+      assert.instanceOf(service, Foo)
+      assert.instanceOf(service.bar, Bar)
+      assert.instanceOf(service.bar.barMethod, FooBar)
+      assert.isFunction(service.fs.writeFileSync)
+      assert.strictEqual(service.param, 'foo-bar')
+      assert.strictEqual(aliasService, service)
+      assert.lengthOf(taggedServices, 2)
+      assert.strictEqual(stringActualParameter, stringExpectedParameter)
+      assert.isArray(arrayActualParameter)
+      assert.strictEqual(service.env, envVariableExpected)
+      assert.strictEqual(service.parameter, stringExpectedParameter)
+      assert.strictEqual(service.property, stringPropertyExpected)
+      assert.instanceOf(fromFactoryWithoutArgs, FooBar)
+      assert.instanceOf(fromFactoryWithArgs, FooBar)
+      assert.instanceOf(fromFactoryWithReferenceWithoutArgs, FooBar)
+      assert.instanceOf(fromFactoryWithReferenceWithArgs, FooBar)
+      assert.instanceOf(fromFactoryWithReferenceWithServiceArg, FooBar)
+      assert.instanceOf(serviceMissingDependencies, MissingDependencies)
+      assert.isNull(serviceMissingDependencies.optional)
+      assert.instanceOf(serviceWithDependencies, MissingDependencies)
+      assert.instanceOf(serviceWithDependencies.optional, FooBar)
+      assert.instanceOf(serviceMissingDependenciesCall, MissingDependencies)
+      assert.isNull(serviceMissingDependenciesCall.optional)
+      assert.instanceOf(serviceWithDependenciesCall, MissingDependencies)
+      assert.instanceOf(serviceWithDependenciesCall.optional, FooBar)
+      assert.isTrue(fooWithTrue.param)
+      assert.isFalse(fooWithFalse.parameter)
+      assert.throw(throwPrivateServiceException, Error,
+        'The service private_service is private')
+      assert.instanceOf(serviceUsingPrivateService.bar, Foo)
+      assert.instanceOf(listener, Listener)
+      assert.instanceOf(mailer, DecoratingMailer)
+      assert.instanceOf(mailer.inner, Mailer)
+      assert.instanceOf(mailerInner, Mailer)
+      assert.isObject(serviceWithObjectParameter.fooManager)
+      assert.instanceOf(decorateAppMailer.inner, DecoratingMailerTwo)
+
+      return assert.lengthOf(arrayActualParameter, 2)
+    })
+
+    it('should load properly a not shared service', async () => {
+      // Arrange.
+      const notSharedServiceName = 'not_shared_service'
+
+      // Act.
+      await loader.load(
+        path.join(__dirname, '/../../../Resources/config/fake-services.xml'))
+      const actual = container.get(notSharedServiceName)
+      const expected = container.get(notSharedServiceName)
+
+      // Assert.
+      return assert.notStrictEqual(actual, expected)
+    })
+
+    it('should load properly synthetic service', async () => {
+      // Arrange.
+      const syntheticServiceName = 'synthetic_service'
+      const syntheticInstance = new SyntheticService()
+      container.set(syntheticServiceName, syntheticInstance)
+
+      // Act.
+      await loader.load(
+        path.join(__dirname, '/../../../Resources/config/fake-services.xml'))
+      const syntheticService = container.get(syntheticServiceName)
+
+      // Assert.
+      return assert.instanceOf(syntheticService, SyntheticService)
+    })
+
+    it('should load properly service without default export', async () => {
+      // Arrange.
+      const serviceName = 'named'
+
+      // Act.
+      await loader.load(
+        path.join(__dirname, '/../../../Resources/config/named-service.xml'))
+      const service = container.get(serviceName)
+
+      // Assert.
+      return assert.instanceOf(service, NamedService)
+    })
+  })
+
+  describe('load multiple imports', () => {
+    beforeEach(() => {
+      container = new ContainerBuilder()
+      container.logger = logger
+      loader = new XmlFileLoader(container)
+    })
+
+    it('should load multiple service files', async () => {
+      // Arrange.
+      const serviceName1 = 'foo'
+      const serviceName2 = 'foo_manager'
+
+      // Act.
+      await loader.load(
+        path.join(__dirname, '/../../../Resources/config/fake-imports.xml'))
+      const service1 = container.get(serviceName1)
+      const service2 = container.get(serviceName2)
+
+      // Assert.
+      assert.instanceOf(service1, Foo)
+
+      return assert.instanceOf(service2, FooManager)
+    })
+
+    it('should load multiple service files in subfolder', async () => {
+      // Arrange.
+      const barServiceName = 'bar'
+      const bazServiceName = 'baz'
+      const configPath = path.join(__dirname,
+        '/../../../Resources/config/fake-import-subfolder.xml')
+
+      // Act.
+      await loader.load(configPath)
+      const bar = container.get(barServiceName)
+      const baz = container.get(bazServiceName)
+
+      // Assert.
+      assert.instanceOf(bar, FooBar)
+      return assert.instanceOf(baz, FooBar)
+    })
+  })
+
+  describe('load with main', () => {
+    beforeEach(async () => {
+      container = new ContainerBuilder()
+      loader = new XmlFileLoader(container)
+      await container.compile()
+    })
+
+    it('should load instance of service properly', async () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/main.xml'
+      )
+
+      // Act.
+      await loader.load(configPath)
+      const one = container.get('classOne')
+      const two = container.get('classTwo')
+      const multipleExports = container.get('multipleExports')
+      const defaultClass = container.get('defaultClass')
+      const kebabCaseFilenameFactory = container.get('kebabCaseFilenameFactory')
+
+      // Assert.
+      assert.instanceOf(one, ClassOne)
+      assert.instanceOf(two, ClassTwo)
+      assert.instanceOf(defaultClass, DefaultClass)
+      assert.instanceOf(kebabCaseFilenameFactory, KebabCaseFilenameClass)
+      return assert.instanceOf(multipleExports, MultipleExports)
+    })
+
+    it('should load instance of service with tagged arguments', async () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/tagged-arguments.xml'
+      )
+
+      // Act.
+      await loader.load(configPath)
+      const repositoryManager = container.get('repository-manager')
+      const repositoryFoo = container.get('repository-foo')
+      const repositoryBar = container.get('repository-bar')
+
+      // Assert.
+      assert.instanceOf(repositoryManager, RepositoryManager)
+      assert.instanceOf(repositoryFoo, RepositoryFoo)
+      assert.instanceOf(repositoryBar, RepositoryBar)
+      assert.equal(repositoryManager.repositories.length, 2)
+    })
+
+    it('should load class from package without errors', async () => {
+      // Arrange.
+      const configPath = path.join(
+        __dirname,
+        '/../../../Resources/config/service_from_package.xml'
+      )
+
+      // Act.
+      await loader.load(configPath)
+      const fooEmitter = container.get('foo_emitter')
+
+      // Assert.
+      assert.instanceOf(fooEmitter, EventEmitter)
+    })
+  })
+})


### PR DESCRIPTION
- Added `fast-xml-parser` dependency for XML parsing.
- Implemented `XmlAdapter` for converting service configurations to XML format.
- Created `XmlDumper` for dumping service data into XML files.
- Developed `XmlFileLoader` to load and parse XML service configurations.
- Defined XML schema for service configuration in `services.xsd`.
- Added multiple test configurations for various service scenarios.
- Implemented tests for `XmlFileLoader` to ensure correct loading and parsing of XML files.

Co-authored-by: Copilot <copilot@github.com>